### PR TITLE
feat: add query command to execute SQL queries

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import { PostgresDriver } from '../drivers/postgres.js';
+import { getActiveConnection } from './connect.js';
+
+async function getActiveDriver(): Promise<{ driver: PostgresDriver; connName: string } | null> {
+  const activeConn = await getActiveConnection();
+  if (!activeConn) {
+    return null;
+  }
+
+  const url = `postgresql://${activeConn.username}:${activeConn.password}@${activeConn.host}:${activeConn.port}/${activeConn.database}`;
+  const driver = new PostgresDriver();
+  await driver.connect(url);
+
+  const connName = activeConn.database;
+  return { driver, connName };
+}
+
+export async function executeQuery(sql: string): Promise<void> {
+  const result = await getActiveDriver();
+
+  if (!result) {
+    console.log(chalk.red('No active database connection.'));
+    console.log(chalk.cyan('Please use "dbcli connect <url>" to connect to a database first.'));
+    process.exit(1);
+  }
+
+  const { driver, connName } = result;
+
+  try {
+    console.log(chalk.gray(`Executing on database "${connName}":`));
+    console.log(chalk.cyan(sql));
+    console.log();
+
+    const queryResult = await driver.query(sql);
+
+    if (queryResult.rows.length === 0) {
+      console.log(chalk.yellow(`Query executed successfully. No rows returned.`));
+      console.log(chalk.gray(`Row count: ${queryResult.rowCount}`));
+    } else {
+      console.table(queryResult.rows);
+      console.log(chalk.gray(`Total: ${queryResult.rows.length} row(s)`));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(chalk.red(`Query failed: ${message}`));
+    process.exit(1);
+  } finally {
+    await driver.disconnect();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { connect, disconnect, showConnections as statusConnections, deleteConnection } from './commands/connect.js';
 import { listTables, describeTable } from './commands/tables.js';
+import { executeQuery } from './commands/query.js';
 
 const program = new Command();
 
@@ -53,6 +54,14 @@ program
   .argument('<table>', 'Table name to describe')
   .action(async (table: string) => {
     await describeTable(table);
+  });
+
+program
+  .command('query')
+  .description('Execute a SQL query')
+  .argument('<sql>', 'SQL query to execute (use quotes for complex queries)')
+  .action(async (sql: string) => {
+    await executeQuery(sql);
   });
 
 program.parse();


### PR DESCRIPTION
- Add 'query <sql>' command to execute arbitrary SQL
- Display SQL before execution for clarity
- Show results in table format
- Use active database connection (enabled: true)
- Show error message if no database is connected